### PR TITLE
improvement: add store_action_name option

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -5,6 +5,7 @@ spark_locals_without_parens = [
   mixin: 1,
   on_actions: 1,
   reference_source?: 1,
+  store_action_name?: 1,
   version_extensions: 1
 ]
 

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ use Ash.Resource,
 
   paper_trail do
     change_tracking_mode :changes_only # default is :snapshot
+    store_action_name? true # default is false
   end
 ```
 

--- a/lib/resource/changes/create_new_version.ex
+++ b/lib/resource/changes/create_new_version.ex
@@ -63,6 +63,7 @@ defmodule AshPaperTrail.Resource.Changes.CreateNewVersion do
       Map.merge(input, %{
         version_source_id: Map.get(result, hd(Ash.Resource.Info.primary_key(changeset.resource))),
         version_action_type: changeset.action.type,
+        version_action_name: changeset.action.name,
         changes: changes
       })
 

--- a/lib/resource/info.ex
+++ b/lib/resource/info.ex
@@ -1,20 +1,6 @@
 defmodule AshPaperTrail.Resource.Info do
   @moduledoc "Introspection helpers for `AshPaperTrail.Resource`"
 
-  @spec reference_source?(Spark.Dsl.t() | Ash.Resource.t()) :: boolean
-  def reference_source?(resource) do
-    Spark.Dsl.Extension.get_opt(resource, [:paper_trail], :reference_source?, true)
-  end
-
-  @spec on_actions(Spark.Dsl.t() | Ash.Resource.t()) :: [atom]
-  def on_actions(resource) do
-    Spark.Dsl.Extension.get_opt(resource, [:paper_trail], :on_actions, nil) ||
-      resource
-      |> Ash.Resource.Info.actions()
-      |> Enum.reject(&(&1.type == :read))
-      |> Enum.map(& &1.name)
-  end
-
   @spec attributes_as_attributes(Spark.Dsl.t() | Ash.Resource.t()) :: [atom]
   def attributes_as_attributes(resource) do
     Spark.Dsl.Extension.get_opt(resource, [:paper_trail], :attributes_as_attributes, [])
@@ -34,6 +20,25 @@ defmodule AshPaperTrail.Resource.Info do
   @spec mixin(Spark.Dsl.t() | Ash.Resource.t()) :: mfa | nil
   def mixin(resource) do
     Spark.Dsl.Extension.get_opt(resource, [:paper_trail], :mixin, nil)
+  end
+
+  @spec on_actions(Spark.Dsl.t() | Ash.Resource.t()) :: [atom]
+  def on_actions(resource) do
+    Spark.Dsl.Extension.get_opt(resource, [:paper_trail], :on_actions, nil) ||
+      resource
+      |> Ash.Resource.Info.actions()
+      |> Enum.reject(&(&1.type == :read))
+      |> Enum.map(& &1.name)
+  end
+
+  @spec reference_source?(Spark.Dsl.t() | Ash.Resource.t()) :: boolean
+  def reference_source?(resource) do
+    Spark.Dsl.Extension.get_opt(resource, [:paper_trail], :reference_source?, true)
+  end
+
+  @spec store_action_name?(Spark.Dsl.t() | Ash.Resource.t()) :: boolean
+  def store_action_name?(resource) do
+    Spark.Dsl.Extension.get_opt(resource, [:paper_trail], :store_action_name?, false)
   end
 
   @spec version_extensions(Spark.Dsl.t() | Ash.Resource.t()) :: Keyword.t()

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -47,7 +47,7 @@ defmodule AshPaperTrail.Resource do
         type: :boolean,
         default: true,
         doc: """
-        Wether or not to create a foreign key reference from the version to the source.
+        Whether or not to create a foreign key reference from the version to the source.
         This should be set to `false` if you are allowing actual deletion of data. Pair
         this extension with `AshArchival` to get soft destroys and referential integrity.
 
@@ -61,6 +61,14 @@ defmodule AshPaperTrail.Resource do
         The mode to use for change tracking. Valid options are `:snapshot` and `:changes_only`.
         `:snapshot` will store the entire resource in the `changes` attribute, while `:changes_only`
         will only store the attributes that have changed.
+        """
+      ],
+      store_action_name?: [
+        type: :boolean,
+        default: false,
+        doc: """
+        Whether or not to add the `version_action_name` attribute to the  version resource. This is
+        useful for auditing purposes. The `version_action_type` attribute is always stored.
         """
       ]
     ]

--- a/lib/resource/transformers/create_version_resource.ex
+++ b/lib/resource/transformers/create_version_resource.ex
@@ -9,6 +9,7 @@ defmodule AshPaperTrail.Resource.Transformers.CreateVersionResource do
     module = Transformer.get_persisted(dsl_state, :module)
     to_skip = AshPaperTrail.Resource.Info.ignore_attributes(dsl_state)
     reference_source? = AshPaperTrail.Resource.Info.reference_source?(dsl_state)
+    store_action_name? = AshPaperTrail.Resource.Info.store_action_name?(dsl_state)
     version_extensions = AshPaperTrail.Resource.Info.version_extensions(dsl_state)
     attributes_as_attributes = AshPaperTrail.Resource.Info.attributes_as_attributes(dsl_state)
 
@@ -125,6 +126,12 @@ defmodule AshPaperTrail.Resource.Transformers.CreateVersionResource do
           attribute :version_action_type, :atom do
             constraints(one_of: [:create, :update, :destroy])
             allow_nil?(false)
+          end
+
+          if unquote(store_action_name?) do
+            attribute :version_action_name, :atom do
+              allow_nil?(true)
+            end
           end
 
           for attr <- unquote(Macro.escape(attributes)) do

--- a/test/ash_paper_trail_test.exs
+++ b/test/ash_paper_trail_test.exs
@@ -63,6 +63,7 @@ defmodule AshPaperTrailTest do
                    ]
                  },
                  version_action_type: :create,
+                 version_action_name: :create,
                  version_source_id: ^post_id
                }
              ] =
@@ -94,6 +95,19 @@ defmodule AshPaperTrailTest do
              ] =
                Posts.Api.read!(Posts.Post.Version, tenant: "acme")
                |> Enum.sort_by(& &1.version_inserted_at)
+    end
+
+    test "the action name is stored" do
+      assert AshPaperTrail.Resource.Info.store_action_name?(Posts.Post) == true
+
+      post = Posts.Post.create!(@valid_attrs, tenant: "acme")
+      Posts.Post.publish!(post, %{}, tenant: "acme")
+
+      [publish_version] =
+        Posts.Api.read!(Posts.Post.Version, tenant: "acme")
+        |> Enum.filter(&(&1.version_action_type == :update))
+
+      assert %{version_action_type: :update, version_action_name: :publish} = publish_version
     end
 
     test "the new version only includes changes in :changes_only mode" do

--- a/test/support/posts/post.ex
+++ b/test/support/posts/post.ex
@@ -11,6 +11,7 @@ defmodule AshPaperTrail.Test.Posts.Post do
   paper_trail do
     attributes_as_attributes [:subject, :body, :tenant]
     change_tracking_mode :changes_only
+    store_action_name? true
   end
 
   code_interface do
@@ -20,10 +21,16 @@ defmodule AshPaperTrail.Test.Posts.Post do
     define :read
     define :update
     define :destroy
+    define :publish
   end
 
   actions do
     defaults [:create, :read, :update, :destroy]
+
+    update :publish do
+      accept []
+      change set_attribute(:published, true)
+    end
   end
 
   multitenancy do
@@ -56,6 +63,11 @@ defmodule AshPaperTrail.Test.Posts.Post do
     attribute :tags, {:array, AshPaperTrail.Test.Posts.Tag} do
       allow_nil? false
       default []
+    end
+
+    attribute :published, :boolean do
+      allow_nil? false
+      default false
     end
   end
 end


### PR DESCRIPTION
Adds a new option for resources:

```
paper_trail do
  store_action_name? true # default false
end
```

If true, then a `version_action_name` attribute will be added to the version resource in addition to `version_action_type`.

fixes #8 