### PR TITLE
Improvement: belongs_to_actor

### DIFF
--- a/.formatter.exs
+++ b/.formatter.exs
@@ -1,5 +1,6 @@
 spark_locals_without_parens = [
   attributes_as_attributes: 1,
+  belongs_to_actor: 3,
   change_tracking_mode: 1,
   ignore_attributes: 1,
   mixin: 1,

--- a/README.md
+++ b/README.md
@@ -84,6 +84,23 @@ This will make your version resource have `foo` and `bar` attributes (they will 
 %ThingVersion{foo: "foo", bar: "bar", changes: %{"foo" => "foo", "bar" => "bar"}}
 ```
 
+## Associating Versions with Actors
+
+You can record the actor who made the change by declaring one or more resources that can be actors.
+
+```
+paper_trail do 
+  belongs_to_actor :user, MyApp.Accounts.User, api: MyApp.Accounts
+  belongs_to_actor :news_feed, MyApp.Accounts.NewsFeed, api: MyApp.Accounts
+end
+```
+
+Each `belongs_to_actor` will create a `belongs_to` relationship with the given name destination. When creating a new version, if the actor on the action is set and matches the resource type, the version will be related to the actor. If your actors are polymorphic or varying types, declare a belongs_to_actor for each type.
+
+A reference is also created with `on_delete: :nilify` and `on_update: :update`
+
+If you need a more complex relationship or your actor is not a resource (e.g. String), the actor is always set on Version create and you can store it by adding `:on_create` `change` in a mixin.
+
 ## Multitenancy
 
 If your resource uses multitenancy, then the strategy, attribute, and parse_attribute options (if any) will be applied to the version resource. If using the attribute strategy you will need to ensure this is also an attribute on the version using the `attributes_as_attributes` option (described above) or via a mixin (described below)

--- a/lib/resource/belongs_to_actor.ex
+++ b/lib/resource/belongs_to_actor.ex
@@ -40,9 +40,4 @@ defmodule AshPaperTrail.Resource.BelongsToActor do
 
   @doc false
   def schema, do: @schema
-
-  @doc false
-  def transform(belongs_to_actor) do
-    {:ok, belongs_to_actor}
-  end
 end

--- a/lib/resource/belongs_to_actor.ex
+++ b/lib/resource/belongs_to_actor.ex
@@ -1,0 +1,48 @@
+defmodule AshPaperTrail.Resource.BelongsToActor do
+  @moduledoc "Represents a belongs_to_actor relationship on a version resource"
+
+  defstruct [
+    :name,
+    :destination,
+    :define_attribute?,
+    :api
+  ]
+
+  @type t :: %__MODULE__{
+          name: atom,
+          destination: Ash.Resource.t(),
+          define_attribute?: boolean
+        }
+
+  @schema [
+    name: [
+      type: :atom,
+      doc: "The name of the relationship to use for the actor (e.g. :user)",
+      required: true
+    ],
+    destination: [
+      type: Ash.OptionsHelpers.ash_resource(),
+      doc: "The resource of the actor (e.g. MyApp.Users.User)"
+    ],
+    api: [
+      type: :atom,
+      doc: """
+      The API module to use when working with the related entity.
+      """
+    ],
+    define_attribute?: [
+      type: :boolean,
+      default: true,
+      doc:
+        "If set to `false` an attribute is not created on the resource for this relationship, and one must be manually added in `attributes`, invalidating many other options."
+    ]
+  ]
+
+  @doc false
+  def schema, do: @schema
+
+  @doc false
+  def transform(belongs_to_actor) do
+    {:ok, belongs_to_actor}
+  end
+end

--- a/lib/resource/belongs_to_actor.ex
+++ b/lib/resource/belongs_to_actor.ex
@@ -2,16 +2,21 @@ defmodule AshPaperTrail.Resource.BelongsToActor do
   @moduledoc "Represents a belongs_to_actor relationship on a version resource"
 
   defstruct [
-    :name,
+    :allow_nil?,
+    :api,
+    :attribute_type,
     :destination,
     :define_attribute?,
-    :api
+    :name
   ]
 
   @type t :: %__MODULE__{
-          name: atom,
+          allow_nil?: boolean,
+          api: atom,
+          attribute_type: term,
           destination: Ash.Resource.t(),
-          define_attribute?: boolean
+          define_attribute?: boolean,
+          name: atom
         }
 
   @schema [
@@ -20,9 +25,11 @@ defmodule AshPaperTrail.Resource.BelongsToActor do
       doc: "The name of the relationship to use for the actor (e.g. :user)",
       required: true
     ],
-    destination: [
-      type: Ash.OptionsHelpers.ash_resource(),
-      doc: "The resource of the actor (e.g. MyApp.Users.User)"
+    allow_nil?: [
+      type: :boolean,
+      default: true,
+      doc:
+        "Whether this relationship must always be present, e.g: must be included on creation, and never removed (it may be modified). The generated attribute will not allow nil values."
     ],
     api: [
       type: :atom,
@@ -30,11 +37,20 @@ defmodule AshPaperTrail.Resource.BelongsToActor do
       The API module to use when working with the related entity.
       """
     ],
+    attribute_type: [
+      type: :any,
+      default: Application.compile_env(:ash, :default_belongs_to_type, :uuid),
+      doc: "The type of the generated created attribute. See `Ash.Type` for more."
+    ],
     define_attribute?: [
       type: :boolean,
       default: true,
       doc:
         "If set to `false` an attribute is not created on the resource for this relationship, and one must be manually added in `attributes`, invalidating many other options."
+    ],
+    destination: [
+      type: Ash.OptionsHelpers.ash_resource(),
+      doc: "The resource of the actor (e.g. MyApp.Users.User)"
     ]
   ]
 

--- a/lib/resource/changes/create_new_version.ex
+++ b/lib/resource/changes/create_new_version.ex
@@ -41,6 +41,11 @@ defmodule AshPaperTrail.Resource.Changes.CreateNewVersion do
 
     change_tracking_mode = AshPaperTrail.Resource.Info.change_tracking_mode(changeset.resource)
 
+    belongs_to_actors =
+      AshPaperTrail.Resource.Info.belongs_to_actor(changeset.resource)
+
+    actor = changeset.context[:private][:actor]
+
     resource_attributes =
       changeset.resource
       |> Ash.Resource.Info.attributes()
@@ -60,7 +65,19 @@ defmodule AshPaperTrail.Resource.Changes.CreateNewVersion do
       |> Enum.reduce(%{}, &build_changes(changeset, &1, &2))
 
     input =
-      Map.merge(input, %{
+      Enum.reduce(belongs_to_actors, input, fn belongs_to_actor, input ->
+        with true <- is_struct(actor) && actor.__struct__ == belongs_to_actor.destination,
+             relationship when not is_nil(relationship) <-
+               Ash.Resource.Info.relationship(version_resource, belongs_to_actor.name) do
+          primary_key = Map.get(actor, hd(Ash.Resource.Info.primary_key(actor.__struct__)))
+          source_attribute = Map.get(relationship, :source_attribute)
+          Map.put(input, source_attribute, primary_key)
+        else
+          _ ->
+            input
+        end
+      end)
+      |> Map.merge(%{
         version_source_id: Map.get(result, hd(Ash.Resource.Info.primary_key(changeset.resource))),
         version_action_type: changeset.action.type,
         version_action_name: changeset.action.name,
@@ -72,7 +89,7 @@ defmodule AshPaperTrail.Resource.Changes.CreateNewVersion do
       |> Ash.Changeset.for_create(:create, input,
         tenant: changeset.tenant,
         authorize?: false,
-        actor: changeset.context[:private][:actor]
+        actor: actor
       )
       |> Ash.Changeset.force_change_attributes(Map.take(private, version_resource_attributes))
       |> changeset.api.create!(return_notifications?: true)

--- a/lib/resource/info.ex
+++ b/lib/resource/info.ex
@@ -10,9 +10,9 @@ defmodule AshPaperTrail.Resource.Info do
   def belongs_to_actor(resource) do
     Spark.Dsl.Extension.get_entities(resource, [:paper_trail])
     |> Enum.filter(fn
-             %AshPaperTrail.Resource.BelongsToActor{} -> true
-             _ -> false
-           end)
+      %AshPaperTrail.Resource.BelongsToActor{} -> true
+      _ -> false
+    end)
   end
 
   @spec change_tracking_mode(Spark.Dsl.t() | Ash.Resource.t()) :: atom

--- a/lib/resource/info.ex
+++ b/lib/resource/info.ex
@@ -6,6 +6,15 @@ defmodule AshPaperTrail.Resource.Info do
     Spark.Dsl.Extension.get_opt(resource, [:paper_trail], :attributes_as_attributes, [])
   end
 
+  @spec belongs_to_actor(Spark.Dsl.t() | Ash.Resource.t()) :: [atom]
+  def belongs_to_actor(resource) do
+    Spark.Dsl.Extension.get_entities(resource, [:paper_trail])
+    |> Enum.filter(fn
+             %AshPaperTrail.Resource.BelongsToActor{} -> true
+             _ -> false
+           end)
+  end
+
   @spec change_tracking_mode(Spark.Dsl.t() | Ash.Resource.t()) :: atom
   def change_tracking_mode(resource) do
     Spark.Dsl.Extension.get_opt(resource, [:paper_trail], :change_tracking_mode, [])

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -21,7 +21,6 @@ defmodule AshPaperTrail.Resource do
     target: AshPaperTrail.Resource.BelongsToActor,
     args: [:name, :destination],
     schema: AshPaperTrail.Resource.BelongsToActor.schema(),
-    transform: {AshPaperTrail.Resource.BelongsToActor, :transform, []}
   }
 
   @paper_trail %Spark.Dsl.Section{
@@ -38,7 +37,6 @@ defmodule AshPaperTrail.Resource do
         A set of attributes that should be set as attributes on the version resource, instead of stored in the freeform `changes` map attribute.
         """
       ],
-      belongs_to_actor: @belongs_to_actor,
       change_tracking_mode: [
         type: {:one_of, [:snapshot, :changes_only]},
         default: :snapshot,

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -9,13 +9,6 @@ defmodule AshPaperTrail.Resource do
     A section for configuring how versioning is derived for the resource.
     """,
     schema: [
-      ignore_attributes: [
-        type: {:list, :atom},
-        default: [],
-        doc: """
-        A list of attributes that should be ignored. `created_at`, `updated_at` and the primary key are always ignored.
-        """
-      ],
       attributes_as_attributes: [
         type: {:list, :atom},
         default: [],
@@ -23,10 +16,55 @@ defmodule AshPaperTrail.Resource do
         A set of attributes that should be set as attributes on the version resource, instead of stored in the freeform `changes` map attribute.
         """
       ],
-      on_actions: [
-        type: {:list, :atom},
+      belongs_to_actor: [
+        args: [:relationship_name, :resource],
         doc: """
-        Which actions should produce new versions. By default, all create/update actions will produce new versions.
+        Creates a belongs_to relationship to version resource. When creating a new version, if the actor is set and matches the 
+        resource type, the version will be related to the actor. If your actors are polymorphic or varying types, declare a 
+        belongs_to_actor for each type.
+
+        The relationship created will always be `allow_nil? true` and foreign key constraints (if any) will unassociate 
+        if the actor record is deleted. If you need more complex relationship, set `define_attribute? false` and add the
+        relationship via a mixin.
+        """,
+        schema: [
+          relationship_name: [
+            type: :atom,
+            doc: "The name of the relationship to use for the actor (e.g. :user)",
+            required: true
+          ],
+          resource: [
+            type: :module,
+            doc: "The resource of the actor (e.g. MyApp.Users.User)",
+            required: true
+          ],
+          api: [
+            type: :module,
+            doc: "The apit of the actor (e.g. MyApp.Users)",
+            required: true
+          ],
+          define_attribute?: [
+            type: :boolean,
+            default: true,
+            doc:
+              "If set to `false` an attribute is not created on the resource for this relationship, and one must be manually added in `attributes`, invalidating many other options."
+          ]
+        ]
+      ],
+      change_tracking_mode: [
+        type: {:one_of, [:snapshot, :changes_only]},
+        default: :snapshot,
+        doc: """
+        The mode to use for change tracking. Valid options are `:snapshot` and `:changes_only`.
+        `:snapshot` will store the entire resource in the `changes` attribute, while `:changes_only`
+        will only store the attributes that have changed.
+        """
+      ],
+      ignore_attributes: [
+        type: {:list, :atom},
+        default: [],
+        doc: """
+        A list of attributes that should be ignored. `created_at`, `updated_at` and the primary key are always ignored.
         """
       ],
       mixin: [
@@ -36,11 +74,10 @@ defmodule AshPaperTrail.Resource do
         A module that defines a `using` macro that will be mixed into the version resource.
         """
       ],
-      version_extensions: [
-        type: :keyword_list,
-        default: [],
+      on_actions: [
+        type: {:list, :atom},
         doc: """
-        Extensions that should be used by the version resource. For example: `extensions: [AshGraphql.Resource], notifier: [Ash.Notifiers.PubSub]`
+        Which actions should produce new versions. By default, all create/update actions will produce new versions.
         """
       ],
       reference_source?: [
@@ -54,21 +91,19 @@ defmodule AshPaperTrail.Resource do
         Only relevant for resources using the AshPostgres data layer.
         """
       ],
-      change_tracking_mode: [
-        type: {:one_of, [:snapshot, :changes_only]},
-        default: :snapshot,
-        doc: """
-        The mode to use for change tracking. Valid options are `:snapshot` and `:changes_only`.
-        `:snapshot` will store the entire resource in the `changes` attribute, while `:changes_only`
-        will only store the attributes that have changed.
-        """
-      ],
       store_action_name?: [
         type: :boolean,
         default: false,
         doc: """
         Whether or not to add the `version_action_name` attribute to the  version resource. This is
         useful for auditing purposes. The `version_action_type` attribute is always stored.
+        """
+      ],
+      version_extensions: [
+        type: :keyword_list,
+        default: [],
+        doc: """
+        Extensions that should be used by the version resource. For example: `extensions: [AshGraphql.Resource], notifier: [Ash.Notifiers.PubSub]`
         """
       ]
     ]

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -6,13 +6,16 @@ defmodule AshPaperTrail.Resource do
   @belongs_to_actor %Spark.Dsl.Entity{
     name: :belongs_to_actor,
     describe: """
-    Creates a belongs_to relationship to version resource. When creating a new version, if the actor is set and matches the 
-    resource type, the version will be related to the actor. If your actors are polymorphic or varying types, declare a 
+    Creates a belongs_to relationship for the actor resource. When creating a new version, if the actor on the action is set and 
+    matches the resource type, the version will be related to the actor. If your actors are polymorphic or varying types, declare a 
     belongs_to_actor for each type.
 
-    The relationship created will always be `allow_nil? true` and foreign key constraints (if any) will unassociate 
-    if the actor record is deleted. If you need more complex relationship, set `define_attribute? false` and add the
-    relationship via a mixin.
+    A reference is also created with `on_delete: :nilify` and `on_update: :update`
+
+    If you need more complex relationships, set `define_attribute? false` and add the relationship via a mixin.
+
+    If your actor is not a resource, add a mixin and with a change for all creates that sets the actor's to one your attributes. 
+    The actor on the version changeset is set.
     """,
     examples: [
       "belongs_to_actor :user, MyApp.Users.User, api: MyApp.Users"
@@ -21,7 +24,6 @@ defmodule AshPaperTrail.Resource do
     target: AshPaperTrail.Resource.BelongsToActor,
     args: [:name, :destination],
     schema: AshPaperTrail.Resource.BelongsToActor.schema()
-    # transform: {AshPaperTrail.Resource.BelongsToActor, :transform, []}
   }
 
   @paper_trail %Spark.Dsl.Section{

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -3,11 +3,33 @@ defmodule AshPaperTrail.Resource do
   Documentation for `AshPaperTrail.Resource`.
   """
 
+  @belongs_to_actor %Spark.Dsl.Entity{
+    name: :belongs_to_actor,
+    describe: """
+    Creates a belongs_to relationship to version resource. When creating a new version, if the actor is set and matches the 
+    resource type, the version will be related to the actor. If your actors are polymorphic or varying types, declare a 
+    belongs_to_actor for each type.
+
+    The relationship created will always be `allow_nil? true` and foreign key constraints (if any) will unassociate 
+    if the actor record is deleted. If you need more complex relationship, set `define_attribute? false` and add the
+    relationship via a mixin.
+    """,
+    examples: [
+      "belongs_to_actor :user, MyApp.Users.User, api: MyApp.Users"
+    ],
+    no_depend_modules: [:destination],
+    target: AshPaperTrail.Resource.BelongsToActor,
+    args: [:name, :destination],
+    schema: AshPaperTrail.Resource.BelongsToActor.schema(),
+    transform: {AshPaperTrail.Resource.BelongsToActor, :transform, []}
+  }
+
   @paper_trail %Spark.Dsl.Section{
     name: :paper_trail,
     describe: """
     A section for configuring how versioning is derived for the resource.
     """,
+    entities: [@belongs_to_actor],
     schema: [
       attributes_as_attributes: [
         type: {:list, :atom},
@@ -16,41 +38,7 @@ defmodule AshPaperTrail.Resource do
         A set of attributes that should be set as attributes on the version resource, instead of stored in the freeform `changes` map attribute.
         """
       ],
-      belongs_to_actor: [
-        args: [:relationship_name, :resource],
-        doc: """
-        Creates a belongs_to relationship to version resource. When creating a new version, if the actor is set and matches the 
-        resource type, the version will be related to the actor. If your actors are polymorphic or varying types, declare a 
-        belongs_to_actor for each type.
-
-        The relationship created will always be `allow_nil? true` and foreign key constraints (if any) will unassociate 
-        if the actor record is deleted. If you need more complex relationship, set `define_attribute? false` and add the
-        relationship via a mixin.
-        """,
-        schema: [
-          relationship_name: [
-            type: :atom,
-            doc: "The name of the relationship to use for the actor (e.g. :user)",
-            required: true
-          ],
-          resource: [
-            type: :module,
-            doc: "The resource of the actor (e.g. MyApp.Users.User)",
-            required: true
-          ],
-          api: [
-            type: :module,
-            doc: "The apit of the actor (e.g. MyApp.Users)",
-            required: true
-          ],
-          define_attribute?: [
-            type: :boolean,
-            default: true,
-            doc:
-              "If set to `false` an attribute is not created on the resource for this relationship, and one must be manually added in `attributes`, invalidating many other options."
-          ]
-        ]
-      ],
+      belongs_to_actor: @belongs_to_actor,
       change_tracking_mode: [
         type: {:one_of, [:snapshot, :changes_only]},
         default: :snapshot,

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -20,7 +20,8 @@ defmodule AshPaperTrail.Resource do
     no_depend_modules: [:destination],
     target: AshPaperTrail.Resource.BelongsToActor,
     args: [:name, :destination],
-    schema: AshPaperTrail.Resource.BelongsToActor.schema(),
+    schema: AshPaperTrail.Resource.BelongsToActor.schema()
+    # transform: {AshPaperTrail.Resource.BelongsToActor, :transform, []}
   }
 
   @paper_trail %Spark.Dsl.Section{
@@ -98,6 +99,7 @@ defmodule AshPaperTrail.Resource do
   use Spark.Dsl.Extension,
     sections: [@paper_trail],
     transformers: [
+      AshPaperTrail.Resource.Transformers.ValidateBelongsToActor,
       AshPaperTrail.Resource.Transformers.RelateVersionResource,
       AshPaperTrail.Resource.Transformers.CreateVersionResource,
       AshPaperTrail.Resource.Transformers.VersionOnChange

--- a/lib/resource/transformers/create_version_resource.ex
+++ b/lib/resource/transformers/create_version_resource.ex
@@ -96,9 +96,13 @@ defmodule AshPaperTrail.Resource.Transformers.CreateVersionResource do
                 table(unquote(table) <> "_versions")
                 repo(unquote(repo))
 
-                unless unquote(reference_source?) do
-                  references do
+                references do
+                  unless unquote(reference_source?) do
                     reference(:version_source, ignore?: true)
+                  end
+
+                  for actor_relationship <- unquote(Macro.escape(belongs_to_actors)) do
+                    reference(actor_relationship.name, on_delete: :nothing, on_update: :update)
                   end
                 end
               end

--- a/lib/resource/transformers/create_version_resource.ex
+++ b/lib/resource/transformers/create_version_resource.ex
@@ -103,7 +103,9 @@ defmodule AshPaperTrail.Resource.Transformers.CreateVersionResource do
                   end
 
                   for actor_relationship <- unquote(Macro.escape(belongs_to_actors)) do
-                    reference(actor_relationship.name, on_delete: :nothing, on_update: :update)
+                    unless actor_relationship.define_attribute? do
+                      reference(actor_relationship.name, on_delete: :nothing, on_update: :update)
+                    end
                   end
                 end
               end

--- a/lib/resource/transformers/create_version_resource.ex
+++ b/lib/resource/transformers/create_version_resource.ex
@@ -156,17 +156,6 @@ defmodule AshPaperTrail.Resource.Transformers.CreateVersionResource do
           update_timestamp :version_updated_at
         end
 
-        relationships do
-          for actor_relationship <- unquote(Macro.escape(belongs_to_actors)) do
-            belongs_to actor_relationship.name, actor_relationship.destination do
-              api(actor_relationship.api)
-              define_attribute?(actor_relationship.define_attribute?)
-              allow_nil?(actor_relationship.allow_nil?)
-              attribute_type(actor_relationship.attribute_type)
-            end
-          end
-        end
-
         actions do
           defaults([:create, :read, :update])
         end
@@ -176,6 +165,15 @@ defmodule AshPaperTrail.Resource.Transformers.CreateVersionResource do
             destination_attribute(unquote(destination_attribute))
             allow_nil?(false)
             attribute_writable?(true)
+          end
+
+          for actor_relationship <- unquote(Macro.escape(belongs_to_actors)) do
+            belongs_to actor_relationship.name, actor_relationship.destination do
+              api(actor_relationship.api)
+              define_attribute?(actor_relationship.define_attribute?)
+              allow_nil?(actor_relationship.allow_nil?)
+              attribute_type(actor_relationship.attribute_type)
+            end
           end
         end
 

--- a/lib/resource/transformers/create_version_resource.ex
+++ b/lib/resource/transformers/create_version_resource.ex
@@ -8,10 +8,12 @@ defmodule AshPaperTrail.Resource.Transformers.CreateVersionResource do
     version_module = AshPaperTrail.Resource.Info.version_resource(dsl_state)
     module = Transformer.get_persisted(dsl_state, :module)
     to_skip = AshPaperTrail.Resource.Info.ignore_attributes(dsl_state)
+
+    attributes_as_attributes = AshPaperTrail.Resource.Info.attributes_as_attributes(dsl_state)
+    belongs_to_actors = AshPaperTrail.Resource.Info.belongs_to_actor(dsl_state)
     reference_source? = AshPaperTrail.Resource.Info.reference_source?(dsl_state)
     store_action_name? = AshPaperTrail.Resource.Info.store_action_name?(dsl_state)
     version_extensions = AshPaperTrail.Resource.Info.version_extensions(dsl_state)
-    attributes_as_attributes = AshPaperTrail.Resource.Info.attributes_as_attributes(dsl_state)
 
     attributes =
       dsl_state
@@ -152,6 +154,17 @@ defmodule AshPaperTrail.Resource.Transformers.CreateVersionResource do
           attribute :changes, :map
           create_timestamp :version_inserted_at
           update_timestamp :version_updated_at
+        end
+
+        relationships do
+          for actor_relationship <- unquote(Macro.escape(belongs_to_actors)) do
+            belongs_to actor_relationship.name, actor_relationship.destination do
+              api(actor_relationship.api)
+              define_attribute?(actor_relationship.define_attribute?)
+              allow_nil?(actor_relationship.allow_nil?)
+              attribute_type(actor_relationship.attribute_type)
+            end
+          end
         end
 
         actions do

--- a/lib/resource/transformers/create_version_resource.ex
+++ b/lib/resource/transformers/create_version_resource.ex
@@ -89,6 +89,7 @@ defmodule AshPaperTrail.Resource.Transformers.CreateVersionResource do
           table = unquote(table)
           repo = unquote(repo)
           reference_source? = unquote(reference_source?)
+          belongs_to_actors = unquote(Macro.escape(belongs_to_actors))
 
           Code.eval_quoted(
             quote do
@@ -177,6 +178,7 @@ defmodule AshPaperTrail.Resource.Transformers.CreateVersionResource do
               define_attribute?(actor_relationship.define_attribute?)
               allow_nil?(actor_relationship.allow_nil?)
               attribute_type(actor_relationship.attribute_type)
+              attribute_writable?(true)
             end
           end
         end

--- a/lib/resource/transformers/validate_belongs_to_actor.ex
+++ b/lib/resource/transformers/validate_belongs_to_actor.ex
@@ -1,0 +1,20 @@
+defmodule AshPaperTrail.Resource.Transformers.ValidateBelongsToActor do
+  @moduledoc "Validates that when multiple belongs_to_actor options are defined that they all allow_nil? true"
+  use Spark.Dsl.Transformer
+
+  def transform(dsl_state) do
+    with entities <- Spark.Dsl.Transformer.get_entities(dsl_state, [:paper_trail]),
+         belongs_to_actors when length(belongs_to_actors) > 1 <-
+           Enum.filter(entities, fn
+             %AshPaperTrail.Resource.BelongsToActor{} -> true
+             _ -> false
+           end),
+         false <-
+           Enum.all?(belongs_to_actors, & &1.allow_nil?) do
+      {:error, "when declaring multiple belongs_to_actors, they all must allow_nil?"}
+    else
+      _ ->
+        {:ok, dsl_state}
+    end
+  end
+end

--- a/test/ash_paper_trail_test.exs
+++ b/test/ash_paper_trail_test.exs
@@ -197,7 +197,8 @@ defmodule AshPaperTrailTest do
       post = Posts.Post.create!(@valid_attrs, tenant: "acme", actor: news_feed)
       post = Posts.Post.publish!(post, tenant: "acme", actor: user)
 
-      post = Posts.Post.update!(post, %{subject: "new subject"}, tenant: "acme", actor: "a string")
+      post =
+        Posts.Post.update!(post, %{subject: "new subject"}, tenant: "acme", actor: "a string")
 
       post_id = post.id
 
@@ -219,7 +220,7 @@ defmodule AshPaperTrailTest do
             user_id: ^user_id,
             news_feed_id: nil
           },
-                    %{
+          %{
             subject: "new subject",
             body: "body",
             version_action_type: :update,

--- a/test/ash_paper_trail_test.exs
+++ b/test/ash_paper_trail_test.exs
@@ -190,26 +190,26 @@ defmodule AshPaperTrailTest do
 
   describe "belongs_to_actor option" do
     test "creates a relationship on the version" do
-        assert length(AshPaperTrail.Resource.Info.belongs_to_actor(Posts.Post)) > 1
+      assert length(AshPaperTrail.Resource.Info.belongs_to_actor(Posts.Post)) > 1
 
-        relationships_on_version = Ash.Resource.Info.relationships(Posts.Post.Version)
-        Enum.each(AshPaperTrail.Resource.Info.belongs_to_actor(Posts.Post), fn belongs_to_actor -> 
-          name = belongs_to_actor.name
-          destination = belongs_to_actor.destination
-          attribute_type = belongs_to_actor.attribute_type
-          api = belongs_to_actor.api
-          allow_nil? = belongs_to_actor.allow_nil?
+      relationships_on_version = Ash.Resource.Info.relationships(Posts.Post.Version)
 
-          assert %Ash.Resource.Relationships.BelongsTo{
-            name: ^name,
-            destination: ^destination,
-            attribute_type: ^attribute_type,
-            source: AshPaperTrail.Test.Posts.Post.Version,
-            api: ^api,
-            allow_nil?: ^allow_nil?
-          } = Enum.find(relationships_on_version, & &1.name == name)
-        end) 
-        
+      Enum.each(AshPaperTrail.Resource.Info.belongs_to_actor(Posts.Post), fn belongs_to_actor ->
+        name = belongs_to_actor.name
+        destination = belongs_to_actor.destination
+        attribute_type = belongs_to_actor.attribute_type
+        api = belongs_to_actor.api
+        allow_nil? = belongs_to_actor.allow_nil?
+
+        assert %Ash.Resource.Relationships.BelongsTo{
+                 name: ^name,
+                 destination: ^destination,
+                 attribute_type: ^attribute_type,
+                 source: AshPaperTrail.Test.Posts.Post.Version,
+                 api: ^api,
+                 allow_nil?: ^allow_nil?
+               } = Enum.find(relationships_on_version, &(&1.name == name))
+      end)
     end
   end
 end

--- a/test/ash_paper_trail_test.exs
+++ b/test/ash_paper_trail_test.exs
@@ -187,4 +187,29 @@ defmodule AshPaperTrailTest do
       assert [] = Articles.Article.read!()
     end
   end
+
+  describe "belongs_to_actor option" do
+    test "creates a relationship on the version" do
+        assert length(AshPaperTrail.Resource.Info.belongs_to_actor(Posts.Post)) > 1
+
+        relationships_on_version = Ash.Resource.Info.relationships(Posts.Post.Version)
+        Enum.each(AshPaperTrail.Resource.Info.belongs_to_actor(Posts.Post), fn belongs_to_actor -> 
+          name = belongs_to_actor.name
+          destination = belongs_to_actor.destination
+          attribute_type = belongs_to_actor.attribute_type
+          api = belongs_to_actor.api
+          allow_nil? = belongs_to_actor.allow_nil?
+
+          assert %Ash.Resource.Relationships.BelongsTo{
+            name: ^name,
+            destination: ^destination,
+            attribute_type: ^attribute_type,
+            source: AshPaperTrail.Test.Posts.Post.Version,
+            api: ^api,
+            allow_nil?: ^allow_nil?
+          } = Enum.find(relationships_on_version, & &1.name == name)
+        end) 
+        
+    end
+  end
 end

--- a/test/ash_paper_trail_test.exs
+++ b/test/ash_paper_trail_test.exs
@@ -195,7 +195,10 @@ defmodule AshPaperTrailTest do
       news_feed_id = news_feed.id
 
       post = Posts.Post.create!(@valid_attrs, tenant: "acme", actor: news_feed)
-      Posts.Post.publish!(post, tenant: "acme", actor: user)
+      post = Posts.Post.publish!(post, tenant: "acme", actor: user)
+
+      post = Posts.Post.update!(post, %{subject: "new subject"}, tenant: "acme", actor: "a string")
+
       post_id = post.id
 
       assert(
@@ -214,6 +217,14 @@ defmodule AshPaperTrailTest do
             version_action_type: :update,
             version_source_id: ^post_id,
             user_id: ^user_id,
+            news_feed_id: nil
+          },
+                    %{
+            subject: "new subject",
+            body: "body",
+            version_action_type: :update,
+            version_source_id: ^post_id,
+            user_id: nil,
             news_feed_id: nil
           }
         ] =

--- a/test/support/accounts/api.ex
+++ b/test/support/accounts/api.ex
@@ -1,0 +1,8 @@
+defmodule AshPaperTrail.Test.Accounts.Api do
+  use Ash.Api, validate_config_inclusion?: false
+
+  resources do
+    resource AshPaperTrail.Test.Accounts.User
+    resource AshPaperTrail.Test.Accounts.NewsFeed
+  end
+end

--- a/test/support/accounts/news_feed.ex
+++ b/test/support/accounts/news_feed.ex
@@ -8,7 +8,7 @@ defmodule AshPaperTrail.Test.Accounts.NewsFeed do
   end
 
   code_interface do
-    define_for AshPaperTrail.Test.Account.Api
+    define_for AshPaperTrail.Test.Accounts.Api
 
     define :create
     define :read

--- a/test/support/accounts/news_feed.ex
+++ b/test/support/accounts/news_feed.ex
@@ -1,0 +1,27 @@
+defmodule AshPaperTrail.Test.Accounts.NewsFeed do
+  use Ash.Resource,
+    data_layer: Ash.DataLayer.Ets,
+    validate_api_inclusion?: false
+
+  ets do
+    private? true
+  end
+
+  code_interface do
+    define_for AshPaperTrail.Test.Account.Api
+
+    define :create
+    define :read
+  end
+
+  actions do
+    defaults [:create, :read]
+    default_accept [:organization]
+  end
+
+  attributes do
+    uuid_primary_key :id
+
+    attribute :organization, :string
+  end
+end

--- a/test/support/accounts/user.ex
+++ b/test/support/accounts/user.ex
@@ -8,7 +8,7 @@ defmodule AshPaperTrail.Test.Accounts.User do
   end
 
   code_interface do
-    define_for AshPaperTrail.Test.Account.Api
+    define_for AshPaperTrail.Test.Accounts.Api
 
     define :create
     define :read

--- a/test/support/accounts/user.ex
+++ b/test/support/accounts/user.ex
@@ -1,0 +1,27 @@
+defmodule AshPaperTrail.Test.Accounts.User do
+  use Ash.Resource,
+    data_layer: Ash.DataLayer.Ets,
+    validate_api_inclusion?: false
+
+  ets do
+    private? true
+  end
+
+  code_interface do
+    define_for AshPaperTrail.Test.Account.Api
+
+    define :create
+    define :read
+  end
+
+  actions do
+    defaults [:create, :read]
+    default_accept [:name]
+  end
+
+  attributes do
+    uuid_primary_key :id
+
+    attribute :name, :string
+  end
+end

--- a/test/support/posts/post.ex
+++ b/test/support/posts/post.ex
@@ -13,7 +13,9 @@ defmodule AshPaperTrail.Test.Posts.Post do
     change_tracking_mode :changes_only
     store_action_name? true
     belongs_to_actor :user, AshPaperTrail.Test.Accounts.User, api: AshPaperTrail.Test.Accounts.Api
-    # belongs_to_actor AshPaperTrail.Test.Accounts.NewsFeed, api: AshPaperTrail.Test.Accounts.Api
+
+    belongs_to_actor :news_feed, AshPaperTrail.Test.Accounts.NewsFeed,
+      api: AshPaperTrail.Test.Accounts.Api
   end
 
   code_interface do

--- a/test/support/posts/post.ex
+++ b/test/support/posts/post.ex
@@ -12,6 +12,8 @@ defmodule AshPaperTrail.Test.Posts.Post do
     attributes_as_attributes [:subject, :body, :tenant]
     change_tracking_mode :changes_only
     store_action_name? true
+    belongs_to_actor :user, AshPaperTrail.Test.Accounts.User, api: AshPaperTrail.Test.Accounts.Api
+    # belongs_to_actor AshPaperTrail.Test.Accounts.NewsFeed, api: AshPaperTrail.Test.Accounts.Api
   end
 
   code_interface do


### PR DESCRIPTION
This add support for one or more belongs_at_actor:

```
paper_trail do 
  belongs_to_actor :user, MyApp.Accounts.User, api: MyApp.Accounts
  belongs_to_actor :news_feed, MyApp.Accounts.NewsFeed, api: MyApp.Accounts
end
```

The Version is resource with the `belongs_to` relationship and when using postgres a `reference`.

When a new version is created, if the actor making a change to the source resource is one of the actor types, the it is associated with the version. If no actor is set or the actor is not a resource then nothing happens.

