### PR TITLE
Fixes: allow ignored attributes to still be attributes

### DIFF
--- a/lib/resource/transformers/create_version_resource.ex
+++ b/lib/resource/transformers/create_version_resource.ex
@@ -7,7 +7,6 @@ defmodule AshPaperTrail.Resource.Transformers.CreateVersionResource do
   def transform(dsl_state) do
     version_module = AshPaperTrail.Resource.Info.version_resource(dsl_state)
     module = Transformer.get_persisted(dsl_state, :module)
-    to_skip = AshPaperTrail.Resource.Info.ignore_attributes(dsl_state)
 
     attributes_as_attributes = AshPaperTrail.Resource.Info.attributes_as_attributes(dsl_state)
     belongs_to_actors = AshPaperTrail.Resource.Info.belongs_to_actor(dsl_state)
@@ -18,7 +17,6 @@ defmodule AshPaperTrail.Resource.Transformers.CreateVersionResource do
     attributes =
       dsl_state
       |> Ash.Resource.Info.attributes()
-      |> Enum.reject(&(&1.name in to_skip))
       |> Enum.filter(&(&1.name in attributes_as_attributes))
 
     data_layer = version_extensions[:data_layer] || Ash.DataLayer.data_layer(dsl_state)


### PR DESCRIPTION
There's no need to ignore an attribute that's explicitly been set to in `attributes_as_attributes`. There are a number of use cases where you don't want to change track an attribute because it won't change, but you do want it as a top-level attribute of the version resource.

Fixes #24 