### PR TITLE
feat!: remove defaults for ignored_attributes

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ use Ash.Resource,
   paper_trail do
     change_tracking_mode :changes_only # default is :snapshot
     store_action_name? true # default is false
+    ignore_attributes [:inserted_at, :updated_at] # the primary keys are always ignored
   end
 ```
 

--- a/lib/resource/changes/create_new_version.ex
+++ b/lib/resource/changes/create_new_version.ex
@@ -34,7 +34,9 @@ defmodule AshPaperTrail.Resource.Changes.CreateNewVersion do
 
     version_changeset = Ash.Changeset.new(version_resource)
 
-    to_skip = AshPaperTrail.Resource.Info.ignore_attributes(changeset.resource)
+    to_skip =
+      Ash.Resource.Info.primary_key(changeset.resource) ++
+        AshPaperTrail.Resource.Info.ignore_attributes(changeset.resource)
 
     attributes_as_attributes =
       AshPaperTrail.Resource.Info.attributes_as_attributes(changeset.resource)

--- a/lib/resource/info.ex
+++ b/lib/resource/info.ex
@@ -22,8 +22,7 @@ defmodule AshPaperTrail.Resource.Info do
 
   @spec ignore_attributes(Spark.Dsl.t() | Ash.Resource.t()) :: [atom]
   def ignore_attributes(resource) do
-    Spark.Dsl.Extension.get_opt(resource, [:paper_trail], :ignore_attributes, []) ++
-      [:created_at, :updated_at] ++ Ash.Resource.Info.primary_key(resource)
+    Spark.Dsl.Extension.get_opt(resource, [:paper_trail], :ignore_attributes, [])
   end
 
   @spec mixin(Spark.Dsl.t() | Ash.Resource.t()) :: mfa | nil

--- a/lib/resource/resource.ex
+++ b/lib/resource/resource.ex
@@ -53,7 +53,7 @@ defmodule AshPaperTrail.Resource do
         type: {:list, :atom},
         default: [],
         doc: """
-        A list of attributes that should be ignored. `created_at`, `updated_at` and the primary key are always ignored.
+        A list of attributes that should be ignored. Typically you'll want to ignore your timestamps. The primary key is always ignored.
         """
       ],
       mixin: [


### PR DESCRIPTION
The default ignored_attributes of `:created_at` and `:updated_at` aren't always necessary and there's no way to remove this.

This removes the defaults and suggests that you add your own in the readme.

Fixes #23 