### PR TITLE
fix: Honour upstream attribute constraints.

### DIFF
--- a/lib/resource/changes/create_new_version.ex
+++ b/lib/resource/changes/create_new_version.ex
@@ -125,7 +125,7 @@ defmodule AshPaperTrail.Resource.Changes.CreateNewVersion do
 
   defp build_changes(changeset, attribute, changes) do
     value = Ash.Changeset.get_attribute(changeset, attribute.name)
-    {:ok, dumped_value} = Ash.Type.dump_to_embedded(attribute.type, value, [])
+    {:ok, dumped_value} = Ash.Type.dump_to_embedded(attribute.type, value, attribute.constraints)
     Map.put(changes, attribute.name, dumped_value)
   end
 end


### PR DESCRIPTION
When the attribute being versioned has a constraint applied, we must also copy that constraint when creating versions.

### Contributor checklist

- [ ] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
