### PR TITLE
fix: correctly carry over first primary key attribute type and constraints

### DIFF
--- a/test/ash_paper_trail/resource/transformers/create_version_resource_test.exs
+++ b/test/ash_paper_trail/resource/transformers/create_version_resource_test.exs
@@ -1,0 +1,46 @@
+defmodule AshPaperTrail.Resource.Transformers.CreateVersionResourceTest do
+  use ExUnit.Case
+
+  defmodule Tag do
+    use Ash.Resource,
+      data_layer: Ash.DataLayer.Ets,
+      extensions: [AshPaperTrail.Resource],
+      validate_api_inclusion?: false
+
+    ets do
+      private? true
+    end
+
+    attributes do
+      attribute :name, :string do
+        allow_nil? false
+        primary_key? true
+        constraints max_length: 20
+      end
+    end
+  end
+
+  defmodule Api do
+    use Ash.Api, extensions: [AshPaperTrail.Api], validate_config_inclusion?: false
+
+    resources do
+      resource Tag
+      resource Tag.Version
+    end
+  end
+
+  describe "attribute :version_source_id" do
+    setup do
+      version_source_id = Ash.Resource.Info.attribute(Tag.Version, :version_source_id)
+      [version_source_id: version_source_id]
+    end
+
+    test "uses resource primary key type", %{version_source_id: version_source_id} do
+      assert version_source_id.type == Ash.Type.String
+    end
+
+    test "uses resource primary key constraints", %{version_source_id: version_source_id} do
+      assert version_source_id.constraints == [allow_empty?: false, trim?: true, max_length: 20]
+    end
+  end
+end


### PR DESCRIPTION
The main problem in 7e825a114210f8eb4d906a63b367bb9808eb989f was using the `attributes` variable to detect the PK (which only contains attrs from `attributes_as_attributes`).

This commit also fixes an issue on the generated `:has_many` relationsip when the resource is using a PK other than `:id`.

See discussion [here](https://elixirforum.com/t/using-ash-paper-trail-together-with-ashuuid-prefixed-pks/61400/1).

### Contributor checklist

- [x] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests
