### PR TITLE
Revert "improvement: add `atomic/3` callback to `CreateNewVersion`"

### DIFF
--- a/lib/resource/changes/create_new_version.ex
+++ b/lib/resource/changes/create_new_version.ex
@@ -16,11 +16,6 @@ defmodule AshPaperTrail.Resource.Changes.CreateNewVersion do
     end
   end
 
-  @impl true
-  def atomic(changeset, opts, context) do
-    change(changeset, opts, context)
-  end
-
   defp create_new_version(changeset) do
     Ash.Changeset.after_action(changeset, fn changeset, result ->
       if changeset.action_type in [:create, :destroy] ||


### PR DESCRIPTION
This reverts commit 3e2a7b4458caed743c4c9fb803c27a962477da9a.

Although the existing modification should have been {:ok, change(changeset, opts, context)} instead of change(changeset, opts, context), even if we fix it that way, we are encountering the error {:error, "Cannot perform a changeset with after action hooks atomically"}, so it seems appropriate to revert it.

### Contributor checklist

- [X] Bug fixes include regression tests
- [ ] Features include unit/acceptance tests

