### PR TITLE
wrong test case of only_when_changed?=true

### DIFF
--- a/test/ash_paper_trail_test.exs
+++ b/test/ash_paper_trail_test.exs
@@ -438,10 +438,11 @@ defmodule AshPaperTrailTest do
   describe "only_when_changed?" do
     test "when set to `true` to versions are not generated when nothing has changed" do
       assert %{subject: "subject", body: "body", id: post_id} =
-               post = Posts.BlogPost.create!(@valid_attrs, tenant: "acme")
+               post =
+               Posts.UpsertPost.create!(%{subject: "subject", body: "body"}, tenant: "acme")
 
       assert %{subject: "subject", body: "body"} =
-               Posts.BlogPost.update!(post, %{subject: "subject", body: "body"}, tenant: "acme")
+               Posts.UpsertPost.update!(post, %{subject: "subject", body: "body"}, tenant: "acme")
 
       assert [
                %{
@@ -449,15 +450,9 @@ defmodule AshPaperTrailTest do
                  body: "body",
                  version_action_type: :create,
                  version_source_id: ^post_id
-               },
-               %{
-                 subject: "subject",
-                 body: "body",
-                 version_action_type: :update,
-                 version_source_id: ^post_id
                }
              ] =
-               Ash.read!(Posts.BlogPost.Version, tenant: "acme")
+               Ash.read!(Posts.UpsertPost.Version, tenant: "acme")
                |> Enum.sort_by(& &1.version_inserted_at)
     end
 

--- a/test/support/posts/upsert_post.ex
+++ b/test/support/posts/upsert_post.ex
@@ -26,13 +26,14 @@ defmodule AshPaperTrail.Test.Posts.UpsertPost do
 
   code_interface do
     define :create
+    define :update
     define :read
     define :upsert
   end
 
   actions do
     default_accept :*
-    defaults [:create, :read]
+    defaults [:create, :update, :read]
 
     create :upsert do
       upsert? true


### PR DESCRIPTION
using UpsertPost for the test case of only_when_changed?=true scenario
as BlogPost has only_when_changed?=false set


# Contributor checklist

Leave anything that you believe does not apply unchecked.

- [ ] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [ ] Refactoring
- [ ] Update dependencies
