### PR TITLE
Fix test nondeterminism - order by UUIDv7 instead of timestamps

### DIFF
--- a/test/ash_paper_trail_test.exs
+++ b/test/ash_paper_trail_test.exs
@@ -10,38 +10,7 @@ defmodule AshPaperTrailTest do
   alias AshPaperTrail.Test.{Accounts, Articles, Posts}
 
   defp sort_versions(versions) do
-    action_order = %{create: 0, publish: 1, update: 2, destroy: 3}
-    type_order = %{create: 0, update: 1, destroy: 2}
-
-    Enum.sort(versions, fn a, b ->
-      cond do
-        a.version_inserted_at != b.version_inserted_at ->
-          DateTime.compare(a.version_inserted_at, b.version_inserted_at) == :lt
-
-        a.version_action_type != b.version_action_type ->
-          (type_order[a.version_action_type] || 99) < (type_order[b.version_action_type] || 99)
-
-        true ->
-          name_a = Map.get(a, :version_action_name, a.version_action_type)
-          name_b = Map.get(b, :version_action_name, b.version_action_type)
-          order_a = Map.get(action_order, name_a, 99)
-          order_b = Map.get(action_order, name_b, 99)
-
-          if order_a != order_b do
-            order_a < order_b
-          else
-            # Same type and name (e.g. two creates) - use body then id
-            body_a = Map.get(a, :body, "") |> to_string()
-            body_b = Map.get(b, :body, "") |> to_string()
-
-            if body_a != body_b do
-              body_a < body_b
-            else
-              to_string(a.id) < to_string(b.id)
-            end
-          end
-      end
-    end)
+    Enum.sort_by(versions, & &1.id)
   end
 
   @valid_attrs %{
@@ -672,8 +641,8 @@ defmodule AshPaperTrailTest do
   end
 
   describe ":primary_key_type options" do
-    test ":id as as UUID" do
-      assert AshPaperTrail.Resource.Info.primary_key_type(Posts.Post) == :uuid
+    test "Posts.Post :id as UUID v7" do
+      assert AshPaperTrail.Resource.Info.primary_key_type(Posts.Post) == :uuid_v7
 
       post = Posts.Post.create!(@valid_attrs, tenant: "acme")
       Posts.Post.update!(post, %{subject: "new subject"}, tenant: "acme")
@@ -682,12 +651,12 @@ defmodule AshPaperTrailTest do
         Ash.read!(Posts.Post.Version, tenant: "acme")
         |> Enum.filter(&(&1.version_action_type == :update))
 
-      uuid = updated_version.id
-      assert {:ok, binary_uuid} = Ash.Type.dump_to_native(Ash.Type.UUID, uuid)
-      assert {:ok, ^uuid} = Ash.Type.cast_input(Ash.Type.UUID, binary_uuid)
+      uuid_v7 = updated_version.id
+      assert {:ok, binary_uuid_v7} = Ash.Type.dump_to_native(Ash.Type.UUID, uuid_v7)
+      assert {:ok, ^uuid_v7} = Ash.Type.cast_input(Ash.Type.UUID, binary_uuid_v7)
     end
 
-    test ":id as UUID v7" do
+    test "Accounts.User :id as UUID v7" do
       assert AshPaperTrail.Resource.Info.primary_key_type(Accounts.User) == :uuid_v7
 
       user = Accounts.User.create!(%{name: "name"})

--- a/test/support/posts/blog_post.ex
+++ b/test/support/posts/blog_post.ex
@@ -18,7 +18,7 @@ defmodule AshPaperTrail.Test.Posts.BlogPost do
   end
 
   paper_trail do
-    primary_key_type :uuid
+    primary_key_type :uuid_v7
     attributes_as_attributes [:subject, :body, :tenant, :secret]
     ignore_attributes [:inserted_at]
     change_tracking_mode :changes_only

--- a/test/support/posts/full_diff_post.ex
+++ b/test/support/posts/full_diff_post.ex
@@ -18,6 +18,7 @@ defmodule AshPaperTrail.Test.Posts.FullDiffPost do
   end
 
   paper_trail do
+    primary_key_type :uuid_v7
     attributes_as_attributes [:subject, :body, :tenant]
     change_tracking_mode :full_diff
   end

--- a/test/support/posts/post.ex
+++ b/test/support/posts/post.ex
@@ -18,7 +18,7 @@ defmodule AshPaperTrail.Test.Posts.Post do
   end
 
   paper_trail do
-    primary_key_type :uuid
+    primary_key_type :uuid_v7
     attributes_as_attributes [:subject, :body, :tenant, :secret]
     ignore_attributes [:inserted_at]
     change_tracking_mode :changes_only

--- a/test/support/posts/upsert_post.ex
+++ b/test/support/posts/upsert_post.ex
@@ -18,7 +18,7 @@ defmodule AshPaperTrail.Test.Posts.UpsertPost do
   end
 
   paper_trail do
-    primary_key_type :uuid
+    primary_key_type :uuid_v7
     attributes_as_attributes [:subject, :body]
     change_tracking_mode :changes_only
     only_when_changed?(true)

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -7,7 +7,7 @@ ExUnit.start()
 defmodule TestHelper do
   def last_version_changes(domain, version_resource) do
     Ash.read!(version_resource, domain: domain)
-    |> Enum.sort_by(& &1.version_inserted_at)
+    |> Enum.sort_by(& &1.id)
     |> List.last()
     |> Map.get(:changes)
   end


### PR DESCRIPTION
# Contributor checklist

- [x] I accept the [AI Policy](https://github.com/ash-project/.github/blob/main/AI_POLICY.md), or AI was not used in the creation of this PR.
- [ ] Bug fixes include regression tests
- [ ] Chores
- [ ] Documentation changes
- [ ] Features include unit/acceptance tests
- [x] Refactoring
- [ ] Update dependencies

Closes #221

The test suite has been non-deterministically failing, because tests were sorting values returned from Ash.read! by timestamp, which is not guaranteed to be transitive *and* different for consecutive changes. This PR changes the primary_key_type of affected data to UUIDv7, and sorts instead by ID, rather than time.